### PR TITLE
nginx-plus: handle POST calls returning 404 till state is updated, use common transport

### DIFF
--- a/src/drove.go
+++ b/src/drove.go
@@ -485,6 +485,28 @@ func writeConf() error {
 func nginxPlus() error {
 	config.RLock()
 	defer config.RUnlock()
+
+	logger.WithFields(logrus.Fields{
+		"nginx": config.Nginxplusapiaddr,
+	}).Info("endpoint")
+
+	endpoint := "http://" + config.Nginxplusapiaddr + "/api"
+	//Create transport here for connection re-use
+	tr := &http.Transport{
+		MaxIdleConns:       30,
+		DisableCompression: true,
+	}
+
+	client := &http.Client{Transport: tr}
+	nginxClient, error := nplus.NewNginxClient(endpoint,nplus.WithHTTPClient(client),nplus.WithAPIVersion(
+		8))
+	if error != nil {
+		logger.WithFields(logrus.Fields{
+			"error": error,
+		}).Error("unable to make call to nginx plus")
+		return error
+	}
+
 	logger.WithFields(logrus.Fields{}).Info("Updating upstreams for the whitelisted drove tags")
 	for _, app := range config.Apps {
 		var newFormattedServers []string
@@ -512,26 +534,6 @@ func nginxPlus() error {
 			"upstreams": newFormattedServers,
 		}).Info("nginx upstreams")
 
-		logger.WithFields(logrus.Fields{
-			"nginx": config.Nginxplusapiaddr,
-		}).Info("endpoint")
-
-		endpoint := "http://" + config.Nginxplusapiaddr + "/api"
-
-		tr := &http.Transport{
-			MaxIdleConns:       30,
-			DisableCompression: true,
-		}
-
-		client := &http.Client{Transport: tr}
-		nginxClient, error := nplus.NewNginxClient(endpoint,nplus.WithHTTPClient(client),nplus.WithAPIVersion(
-			8))
-		if error != nil {
-			logger.WithFields(logrus.Fields{
-				"error": error,
-			}).Error("unable to make call to nginx plus")
-			return error
-		}
 		upstreamtocheck := app.Vhost
 		var finalformattedServers []nplus.UpstreamServer
 
@@ -539,8 +541,26 @@ func nginxPlus() error {
 			formattedServer := nplus.UpstreamServer{Server: server, MaxFails: config.MaxFailsUpstream, FailTimeout: config.FailTimeoutUpstream, SlowStart: config.SlowStartUpstream}
 			finalformattedServers = append(finalformattedServers, formattedServer)
 		}
+		// If upstream has no servers, UpdateHTTPServers returns error as in-line GetHTTPServers returns error. server ID 0 needs to be explicitly initiated by a PATCH
                 err := nginxClient.CheckIfUpstreamExists(upstreamtocheck)
-                if err != nil {
+		if err != nil {
+			// First add atleast one server to initialise upstream to support UpdateHTTPServers
+			logger.WithFields(logrus.Fields{
+				"Adding fresh upstream for": upstreamtocheck,
+			}).Info("Adding first server for upstream")
+			//Adding first server for server ID 0. ID 0 needs to be updated if state file is resurrected when a vhost gets resurrected. Create ID 0 otherwise.
+			error := nginxClient.UpdateHTTPServer(upstreamtocheck, finalformattedServers[0])
+
+			// Now upstream should have servers, update earlier state to let UpdateHTTPServers take over
+			//But wait from some time for nginx to actually update it's state. Consecutive calls would still return a 404 if you don't wait long enough
+			if error != nil {
+				time.Sleep(100 * time.Millisecond)
+			}
+
+			err = nginxClient.CheckIfUpstreamExists(upstreamtocheck)
+
+		}
+		 if err == nil {
                         added, deleted, updated, error := nginxClient.UpdateHTTPServers(upstreamtocheck, finalformattedServers)
 
                         if added != nil {
@@ -565,11 +585,7 @@ func nginxPlus() error {
                                 return error
                         }
                 } else {
-                                logger.WithFields(logrus.Fields{
-                                        "Upstream doesn't exist in Nginx": upstreamtocheck,
-                                }).Error("Config reload required to add the upstream back")
-                                return err
-                        reloadAllApps(true)
+			return err
                 }
 	}
 	return nil

--- a/src/drove.go
+++ b/src/drove.go
@@ -565,6 +565,7 @@ func nginxPlus() error {
                                                                 "Adding fresh upstream for": upstreamtocheck,
                                                         }).Error("Context timeout waiting for CheckIfUpstreamExists")
                                                 default:
+							time.Sleep(5 * time.Millisecond)
                                                         err = nginxClient.CheckIfUpstreamExists(upstreamtocheck)
                                         }
                                 }


### PR DESCRIPTION
1. Use common transport for api calls
2. Initialiser server ID=0 for new upstream that doesn't exist as UpdateHTTPServers relies on GetHTTPServers to return valid data to determine diff to update
3.  Wait for newly initialised upstream to return valid data