### PR TITLE
fix the newapp.groups[].hosts to contain both existing hosts and new …

### DIFF
--- a/src/drove.go
+++ b/src/drove.go
@@ -488,6 +488,7 @@ func syncAppsAndVhosts(droveConfig DroveConfig, jsonapps *DroveApps, vhosts *Vho
 					newapp.Groups = existingApp.Groups
 					if existingGroup, ok := newapp.Groups[groupName]; ok {
 						existingGroup.Hosts = append(newapp.Hosts, existingGroup.Hosts...)
+						newapp.Groups[groupName] = existingGroup
 					} else {
 						newapp.Groups[groupName] = hostGroup
 					}


### PR DESCRIPTION
Currently, the hosts are not getting updated correctly in the `newapp.Groups[groupName].Hosts`. When we do `newapp.Groups[groupName]`, we get an object by value. Updating hosts to this copy won't update the origin object. Thus needs to be reassigned to `newapp.Groups[groupName]`.