### PR TITLE
nginx+: only update upstream for http/s vhosts till streams support is added

### DIFF
--- a/src/reload.go
+++ b/src/reload.go
@@ -266,6 +266,7 @@ func nginxPlus(data *RenderingData) error {
 
 	logger.WithFields(logrus.Fields{"apps": data.Apps}).Debug("Updating upstreams for the whitelisted http/s drove vhosts")
 	for _, app := range data.Apps {
+		//Ensure UpdateHTTPServers is not called for streams TCP/UDP instances
 		isHTTPVHost := false
 		for _, t := range app.Hosts {
 			if (string(t.PortType) == "http") || (string(t.PortType) == "https") {
@@ -273,6 +274,7 @@ func nginxPlus(data *RenderingData) error {
 			}
 
 		}
+
 		if isHTTPVHost {
 			var newFormattedServers []string
 			for _, t := range app.Hosts {


### PR DESCRIPTION
Currently we were assuming all non-https as http in template
```
- $ptype_map := index $app.Hosts 0
- if eq $ptype_map.PortType "https"
proxy_pass [https://\](https://github.com/PhonePe/drove-gateway/pull/8)$app.Vhost;
- else
proxy_pass [http://\](http:)$app.Vhost;
```
 
Hence we were trying to use http for tcp instances but attempts were being made to route to them
Fixing this to stop routing streams
```
- if eq $ptype_map.PortType "https"
proxy_pass https://$/{{tolower $vid}}pool;
- else if eq $ptype_map.PortType "http"
proxy_pass http://$/{{tolower $vid}}pool;
- end
```
 
For routing streams, every instance need to have it's own port on nixy, it's not possible in the current architecture as there is no SNI on TCP
 
With above template fix, nginx+ is still trying to update upstreams for streams but with UpdateHTTPServers api as this logic doesn't exclude streams. 